### PR TITLE
fix(css): make avatar responsive

### DIFF
--- a/public/assets/css/main.css
+++ b/public/assets/css/main.css
@@ -735,6 +735,7 @@
 				margin: 0 auto;
 				border-radius: 100%;
 				box-shadow: 0 0 0 1.5em #ffffff;
+				max-width: 100%;
 			}
 
 			#main .avatar:before {


### PR DESCRIPTION
I noticed the avatar was oversized on mobile:

![image](https://cloud.githubusercontent.com/assets/12798751/17488492/a83cf47e-5d67-11e6-91ef-148ad1f86a2d.png)

So I made it responsive:

![image](https://cloud.githubusercontent.com/assets/12798751/17488503/b14d7d86-5d67-11e6-91ae-283a7205e6f5.png)

Unfortunately, I couldn't test this locally since there was an issue with Express.
